### PR TITLE
Replace Tini with docker run --init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:6.11
 
-ENV TINI_VERSION v0.15.0
-
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -10,7 +8,4 @@ ADD package.json /usr/src/app/
 RUN npm install && npm cache clean
 COPY . /usr/src/app
 
-# Add Tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "bin/aws-es-proxy", "--"]
+ENTRYPOINT ["bin/aws-es-proxy", "--"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker build -t aws-es-proxy .
 Run and specify credentials via ENV variables.
 
 ```
-docker run -it --rm -p 9210:9200 \
+docker run --init -it --rm -p 9210:9200 \
   -e AWS_ACCESS_KEY_ID=... \
   -e AWS_SECRET_ACCESS_KEY=... \
   aws-es-proxy <elasticsearch_url>
@@ -56,7 +56,7 @@ docker run -it --rm -p 9210:9200 \
 Utilise configuration and profiles from the host.
 
 ```
-docker run -it -v $HOME/.aws:/root/.aws --rm -p 9210:9200 \
+docker run --init -it -v $HOME/.aws:/root/.aws --rm -p 9210:9200 \
   aws-es-proxy --profile <profile_name> <elasticsearch_url>
 ```
 


### PR DESCRIPTION
As of Docker API 1.25, the Tini package has been integrated as `docker run --init`.

This permits the proxy to build and run under Docker for Apple silicon.